### PR TITLE
Fix: Change to symmetric strip when scanning for CHARACTERISTIC/MEASUREMENT headers

### DIFF
--- a/src/countach/fileops.py
+++ b/src/countach/fileops.py
@@ -13,7 +13,7 @@ def _linesToSections(lines: List[str]) -> List[List[str]]:
 	currentOutput = []
 	for rawline in lines:
 		# Remove leading and trailing whitespace
-		line = rawline.lstrip()[:-1]
+		line = rawline.strip()
 
 		if line == "/begin CHARACTERISTIC" or line == "/begin MEASUREMENT":
 			inSection = True


### PR DESCRIPTION
# Bug
Discovered that when using this for A2L files generated by Matlab, several measurements and characteristics were not ingested. 
# Fix
Upon changing to a symmetric strip method, all items were successfully parsed.